### PR TITLE
Create structs for main record types

### DIFF
--- a/lib/nacha/record.ex
+++ b/lib/nacha/record.ex
@@ -1,0 +1,53 @@
+defmodule Nacha.Record do
+  @moduledoc """
+  A use macro for building and formatting NACHA records.
+  """
+
+  defmacro __using__(opts) do
+    quote do
+      import Kernel, except: [to_string: 1]
+
+      @keys unquote(Keyword.get(opts, :keys))
+
+      defstruct Enum.map(@keys, fn
+        {key, _, _} -> key
+        {key, _, _, default} -> {key, default}
+      end)
+
+      @type t :: %__MODULE__{}
+
+      @spec to_string(__MODULE__.t) :: String.t
+      def to_string(%__MODULE__{} = record),
+        do: unquote(__MODULE__).to_string(record, @keys)
+
+      @spec to_iolist(__MODULE__.t) :: iolist
+      def to_iolist(%__MODULE__{} = record),
+        do: unquote(__MODULE__).to_iolist(record, @keys)
+    end
+  end
+
+  @typep key_def :: {atom, atom, integer} | {atom, atom, integer, any}
+
+  @spec to_string(struct, list(key_def)) :: String.t
+  def to_string(record, keys), do: record |> to_iolist(keys) |> to_string
+
+  @spec to_iolist(struct, list(key_def)) :: iolist
+  def to_iolist(record, keys),
+    do: Enum.reduce(keys, [], &([&2, format_field(record, &1)]))
+
+  defp format_field(record, {key, type, length, _}),
+    do: format_field(record, {key, type, length})
+  defp format_field(record, {key, type, length}),
+    do: record |> Map.get(key, "") |> format_value(length, type) |> pad(length, type)
+
+  defp format_value(date, _, :date),
+    do: date |> Date.to_iso8601(:basic) |> String.slice(2, 6)
+  defp format_value(time, _, :time),
+    do: time |> Time.to_iso8601(:basic) |> String.slice(0, 4)
+  defp format_value(value, length, _type),
+    do: value |> to_string() |> String.slice(0, length)
+
+  defp pad(val, length, :number), do: String.pad_leading(val, length, "0")
+  defp pad(val, length, :string), do: String.pad_trailing(val, length, " ")
+  defp pad(val, _, _), do: val
+end

--- a/lib/nacha/records/batch_control.ex
+++ b/lib/nacha/records/batch_control.ex
@@ -1,0 +1,18 @@
+defmodule Nacha.Records.BatchControl do
+  @moduledoc """
+  A struct containing data for a batch control record.
+  """
+
+  use Nacha.Record, keys: [
+    {:record_type_code,   :number, 1,   8},
+    {:service_class_code, :string, 3},
+    {:entry_count,        :number, 6,   0},
+    {:entry_hash,         :number, 10},
+    {:total_debits,       :number, 12},
+    {:total_credits,      :number, 12},
+    {:company_id,         :string, 10},
+    {:message_auth_code,  :string, 19},
+    {:reserved,           :string, 6},
+    {:odfi_id,            :string, 8},
+    {:batch_number,       :number, 7}]
+end

--- a/lib/nacha/records/batch_header.ex
+++ b/lib/nacha/records/batch_header.ex
@@ -1,0 +1,20 @@
+defmodule Nacha.Records.BatchHeader do
+  @moduledoc """
+  A struct containing data for a batch header record.
+  """
+
+  use Nacha.Record, keys: [
+    {:record_type_code,     :number, 1,   5},
+    {:service_class_code,   :string, 3},
+    {:company_name,         :string, 16},
+    {:discretionary_data,   :string, 20},
+    {:company_id,           :string, 10},
+    {:standard_entry_class, :string, 3},
+    {:entry_description,    :string, 10},
+    {:descriptive_date,     :date,   6},
+    {:effective_date,       :date,   6},
+    {:settlement_date,      :string, 3},
+    {:originator_status,    :string, 1,   "1"},
+    {:odfi_id,              :string, 8},
+    {:batch_number,         :number, 7}]
+end

--- a/lib/nacha/records/entry_detail.ex
+++ b/lib/nacha/records/entry_detail.ex
@@ -1,0 +1,19 @@
+defmodule Nacha.Records.EntryDetail do
+  @moduledoc """
+  A struct containing data for an individual entry detail record,
+  which represents a single transfer.
+  """
+
+  use Nacha.Record, keys: [
+    {:record_type_code,   :number, 1,   6},
+    {:transaction_code,   :string, 2},
+    {:rdfi_id,            :number, 8},
+    {:check_digit,        :number, 1},
+    {:account_number,     :string, 17},
+    {:amount,             :number, 10},
+    {:individual_id,      :string, 15},
+    {:individual_name,    :string, 22},
+    {:discretionary_data, :string, 2},
+    {:addenda_indicator,  :number, 1,   0},
+    {:trace_number,       :string, 15}]
+end

--- a/lib/nacha/records/file_control.ex
+++ b/lib/nacha/records/file_control.ex
@@ -1,0 +1,15 @@
+defmodule Nacha.Records.FileControl do
+  @moduledoc """
+  A struct containing data for a file control record.
+  """
+
+  use Nacha.Record, keys: [
+    {:record_type_code, :number, 1,   9},
+    {:batch_count,      :number, 6},
+    {:block_count,      :number, 6},
+    {:entry_count,      :number, 8},
+    {:entry_hash,       :number, 10},
+    {:total_debits,     :number, 12},
+    {:total_credits,    :number, 12},
+    {:reserved,         :string, 39}]
+end

--- a/lib/nacha/records/file_header.ex
+++ b/lib/nacha/records/file_header.ex
@@ -1,0 +1,21 @@
+defmodule Nacha.Records.FileHeader do
+  @moduledoc """
+  A struct containing data for a file control record.
+  """
+
+  use Nacha.Record, keys: [
+    {:record_type_code,           :number, 1,   1},
+    {:priority_code,              :string, 2,   "01"},
+    {:separator,                  :string, 1},
+    {:immediate_destination,      :string, 9},
+    {:immediate_origin,           :string, 10},
+    {:creation_date,              :date,   6},
+    {:creation_time,              :time,   4},
+    {:file_id_modifier,           :string, 1,   "A"},
+    {:record_size,                :number, 3,   94},
+    {:block_size,                 :number, 2,   10},
+    {:format_code,                :string, 1,   "1"},
+    {:immediate_destination_name, :string, 23},
+    {:immediate_origin_name,      :string, 23},
+    {:reference_code,             :string, 8}]
+end

--- a/test/lib/records/batch_control_test.exs
+++ b/test/lib/records/batch_control_test.exs
@@ -1,0 +1,19 @@
+defmodule Nacha.Records.BatchControlTest do
+  use ExUnit.Case, async: true
+
+  alias Nacha.Records.BatchControl, as: Control
+
+  @sample_record %Control{
+    service_class_code: "200", entry_count: 12, entry_hash: 12345678,
+    total_debits: 123456, total_credits: 123456, company_id: "1419871234",
+    odfi_id: "09991234", batch_number: 1}
+  @sample_string "820000001200123456780000001234560000001234561419871234" <>
+    "                         099912340000001"
+
+  test "formatting the record as a string" do
+    string = Control.to_string(@sample_record)
+
+    assert String.length(string) == 94
+    assert string == @sample_string
+  end
+end

--- a/test/lib/records/batch_header_test.exs
+++ b/test/lib/records/batch_header_test.exs
@@ -1,0 +1,21 @@
+defmodule Nacha.Records.BatchHeaderTest do
+  use ExUnit.Case, async: true
+
+  alias Nacha.Records.BatchHeader, as: Header
+
+  @sample_record %Header{
+    service_class_code: "200", company_name: "My Best Comp.",
+    discretionary_data: "Includes overtime", company_id: "1419871234",
+    standard_entry_class: "PPD", entry_description: "Payroll",
+    descriptive_date: ~D[2006-02-05], effective_date: ~D[2006-02-05],
+    odfi_id: "09991234", batch_number: 1}
+  @sample_string "5200My Best Comp.   Includes overtime   1419871234PPD" <>
+    "Payroll   060205060205   1099912340000001"
+
+  test "formatting the record as a string" do
+    string = Header.to_string(@sample_record)
+
+    assert String.length(string) == 94
+    assert string == @sample_string
+  end
+end

--- a/test/lib/records/entry_detail_test.exs
+++ b/test/lib/records/entry_detail_test.exs
@@ -1,0 +1,19 @@
+defmodule Nacha.Records.EntryDetailTest do
+  use ExUnit.Case, async: true
+
+  alias Nacha.Records.EntryDetail
+
+  @sample_record %EntryDetail{
+    transaction_code: "27", rdfi_id: 12345678, check_digit: 9,
+    account_number: "012345678", amount: "9999", individual_id: "1234567890",
+    individual_name: "Bob Loblaw", trace_number: "1234567890"}
+  @sample_string "627123456789012345678        00000099991234567890     " <>
+    "Bob Loblaw              01234567890     "
+
+  test "formatting the record as a string" do
+    string = EntryDetail.to_string(@sample_record)
+
+    assert String.length(string) == 94
+    assert string == @sample_string
+  end
+end

--- a/test/lib/records/file_control_test.exs
+++ b/test/lib/records/file_control_test.exs
@@ -1,0 +1,18 @@
+defmodule Nacha.Records.FileControlTest do
+  use ExUnit.Case, async: true
+
+  alias Nacha.Records.FileControl, as: Control
+
+  @sample_record %Control{
+    batch_count: 4, block_count: 5, entry_count: 42, entry_hash: 12345678,
+    total_debits: 123456, total_credits: 123456}
+  @sample_string "9000004000005000000420012345678000000123456000000123456" <>
+    "                                       "
+
+  test "formatting the record as a string" do
+    string = Control.to_string(@sample_record)
+
+    assert String.length(string) == 94
+    assert string == @sample_string
+  end
+end

--- a/test/lib/records/file_header_test.exs
+++ b/test/lib/records/file_header_test.exs
@@ -1,0 +1,21 @@
+defmodule Nacha.Records.FileHeaderTest do
+  use ExUnit.Case, async: true
+
+  alias Nacha.Records.FileHeader, as: Header
+
+  @sample_record %Header{
+    immediate_destination: "123456789", immediate_origin: "0123456789",
+    creation_date: ~D[2017-01-01], creation_time: ~T[12:00:00],
+    immediate_destination_name: "Receiving Bank",
+    immediate_origin_name: "First Origination Bank of Internet",
+    reference_code: "12345678"}
+  @sample_string "101 12345678901234567891701011200A094101" <>
+    "Receiving Bank         First Origination Bank 12345678"
+
+  test "formatting the record as a string" do
+    string = Header.to_string(@sample_record)
+
+    assert String.length(string) == 94
+    assert string == @sample_string
+  end
+end


### PR DESCRIPTION
Add structs to store data for basic record types, including functions to convert the record data into a compliant string.

- [x] File Header
- [x] Batch Header
- [x] Entry Detail
- [x] Batch Control
- [x] File Control