### PR TITLE
feat: support separate company_name param in Nacha.build/3

### DIFF
--- a/lib/nacha/file.ex
+++ b/lib/nacha/file.ex
@@ -38,6 +38,7 @@ defmodule Nacha.File do
           optional(:descriptive_date) => String.t(),
           optional(:file_id_modifier) => String.t(),
           optional(:entry_description) => String.t(),
+          optional(:company_name) => String.t(),
           immediate_destination: String.t(),
           immediate_origin: String.t(),
           immediate_destination_name: String.t(),
@@ -117,7 +118,7 @@ defmodule Nacha.File do
       %{
         batch_number: batch_num,
         company_id: params.company_id,
-        company_name: params.immediate_origin_name,
+        company_name: Map.get(params, :company_name, params.immediate_origin_name),
         effective_date: params.effective_date,
         descriptive_date: Map.get(params, :descriptive_date),
         entry_description: Map.get(params, :entry_description),

--- a/test/lib/file_test.exs
+++ b/test/lib/file_test.exs
@@ -225,6 +225,24 @@ defmodule Nacha.FileTest do
     test "calculates the credit total", %{subject: file} do
       assert file.control_record.total_credits == 1066
     end
+
+    test "defaults batch company_name to immediate_origin_name", %{subject: file} do
+      Enum.each(file.batches, fn batch ->
+        assert batch.header_record.company_name == "Sell Co"
+      end)
+    end
+
+    test "uses company_name param when provided" do
+      params = Map.put(@valid_params, :company_name, "Custom Name")
+      {:ok, file} = NachaFile.build(@entries, params)
+
+      Enum.each(file.batches, fn batch ->
+        assert batch.header_record.company_name == "Custom Name"
+      end)
+
+      # file header immediate_origin_name remains unchanged
+      assert file.header_record.immediate_origin_name == "Sell Co"
+    end
   end
 
   test "formatting a file as a string" do


### PR DESCRIPTION
Closes #14

## Summary

- Allow an optional `company_name` key in the params map passed to `Nacha.build/3`
- Falls back to `immediate_origin_name` when not provided (fully backwards compatible)
- Adds `optional(:company_name) => String.t()` to the `build_file_params` type

## Motivation

In the NACHA format, the file header's `immediate_origin_name` (23 chars) and the batch header's `company_name` (16 chars) are distinct fields with different purposes:

- `immediate_origin_name`: identifies the originator to the receiving bank
- `company_name`: what appears on the end customer's bank statement

Previously, `build_batch/4` hardcoded `company_name: params.immediate_origin_name`, making it impossible to set these independently. This is needed when a bank (e.g. Axos) requires different company names for debit vs credit batches while the file-level originator name stays the same.

## Changes

**`lib/nacha/file.ex`**:
```diff
- company_name: params.immediate_origin_name,
+ company_name: Map.get(params, :company_name, params.immediate_origin_name),
```

Plus the type spec update to include `optional(:company_name)`.

**`test/lib/file_test.exs`**: Two new tests verifying default behavior (unchanged) and explicit `company_name` override.

## Test plan

- All 58 existing tests pass
- New test: verify `company_name` defaults to `immediate_origin_name` when not provided
- New test: verify `company_name` overrides batch header while `immediate_origin_name` in file header stays unchanged